### PR TITLE
fix: fixes seeder not able to find seeder class / schema command triggers seeder by default

### DIFF
--- a/packages/cli/src/commands/SchemaCommandFactory.ts
+++ b/packages/cli/src/commands/SchemaCommandFactory.ts
@@ -53,7 +53,6 @@ export class SchemaCommandFactory {
       args.option('seed', {
         type: 'string',
         desc: 'Allows to seed the database on create or drop and recreate',
-        default: '',
       });
     }
 

--- a/packages/seeder/src/seed-manager.ts
+++ b/packages/seeder/src/seed-manager.ts
@@ -26,7 +26,7 @@ export class SeedManager {
     for (const seederClass of seederClasses) {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const seeder = require(`${process.cwd()}/${this.orm.config.get('seeder').path}/${this.getFileName(seederClass)}`);
-      await this.seed(seeder);
+      await this.seed(seeder[seederClass] || seeder.default);
     }
   }
 
@@ -51,12 +51,12 @@ export class SeedManager {
     await ensureDir(Utils.normalizePath(this.orm.config.get('seeder').path));
   }
 
-  private async generate(seeder: string): Promise<string> {
+  private async generate(seederClass: string): Promise<string> {
     const path = Utils.normalizePath(this.orm.config.get('seeder').path);
-    const fileName = this.getFileName(seeder);
+    const fileName = this.getFileName(seederClass);
     const ret = `import { EntityManager } from '@mikro-orm/core';
 import { Seeder } from '@mikro-orm/seeder';
-class DatabaseSeeder extends Seeder {
+export class ${seederClass} extends Seeder {
 
   run(em: EntityManager): Promise<void> {
   }


### PR DESCRIPTION
Fixes:
- Seeder is not able to find/instantiate correct seeder class
- When creating seeder from cli:
-- Class name is not reflected in generated code file
- `mikro-orm schema:create --run` should not trigger seeeder(s) by default